### PR TITLE
Improve accessibility for social links and text contrast

### DIFF
--- a/src/components/ButtonRotatingBackgroundGradient.tsx
+++ b/src/components/ButtonRotatingBackgroundGradient.tsx
@@ -4,12 +4,15 @@ interface ButtonRotatingBackgroundGradient {
 
 const ButtonRotatingBackgroundGradient: React.FC<ButtonRotatingBackgroundGradient> = ({ children }) => {
     return (
-        <button className='relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:ring-offset-gray-50'>
+        <span
+            aria-hidden="true"
+            className='relative inline-flex h-12 overflow-hidden rounded-full p-[1px]'
+        >
             <span className='absolute inset-[-1000%] animate-[spin_2s_linear_infinite] dark:bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]' />
-            <span className='inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full dark:bg-gray-950 px-3 py-1 text-sm font-medium dark:text-gray-50 backdrop-blur-3xl transition-all duration-300 dark:hover:bg-gray-900 hover:bg-gray-200 shadow-lg shadow-indigo-500/40 bg-neutral-100 text-neutral-600 shadow-light-3 hover:bg-neutral-200 hover:shadow-light-2 focus:bg-neutral-200 focus:shadow-light-2 active:bg-neutral-200 active:shadow-light-2'>
-            <div className="flex gap-x-2 items-center">{children}</div>
+            <span className='inline-flex h-full w-full items-center justify-center rounded-full dark:bg-gray-950 px-3 py-1 text-sm font-medium dark:text-gray-50 backdrop-blur-3xl transition-all duration-300 dark:hover:bg-gray-900 hover:bg-gray-200 shadow-lg shadow-indigo-500/40 bg-neutral-100 text-neutral-600 shadow-light-3 hover:bg-neutral-200 hover:shadow-light-2 active:bg-neutral-200 active:shadow-light-2'>
+                <div className="flex gap-x-2 items-center">{children}</div>
             </span>
-        </button>
+        </span>
     );
 };
 

--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -18,7 +18,7 @@ const { title, description, date, link, isFirst } =
 >
 </div>
 <span
-    class={`${isFirst ? "text-xl font-bold text-zinc-800 dark:text-zinc-200" : ""} mb-1 text-sm font-normal leading-none text-zinc-400 dark:text-zinc-500`}
+    class={`${isFirst ? "text-xl font-bold text-zinc-800 dark:text-zinc-200" : ""} mb-1 text-sm font-normal leading-none text-zinc-600 dark:text-zinc-400`}
 >
     {date}
 </span>
@@ -26,7 +26,7 @@ const { title, description, date, link, isFirst } =
     {title}
 </h3>
 <p
-    class="mb-4 text-base font-normal text-zinc-500 dark:text-zinc-400 text-pretty"
+    class="mb-4 text-base font-normal text-zinc-700 dark:text-zinc-300 text-pretty"
 >
     {description}
 </p>

--- a/src/components/SocialPill.astro
+++ b/src/components/SocialPill.astro
@@ -8,6 +8,8 @@ import ButtonRotatingBackgroundGradient from "./ButtonRotatingBackgroundGradient
     target="_blank"
     rel="noopener noreferrer"
     title={Astro.props.title}
+    aria-label={Astro.props.title}
+    class="inline-block rounded-full focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:ring-offset-gray-50"
 >
     <ButtonRotatingBackgroundGradient>
         <slot />


### PR DESCRIPTION
## Summary
- remove unnecessary button element and expose decorative span
- add accessible labels and focus styles to social links
- increase text contrast in experience items

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68946774de18832c980b489b0005cb6b