### PR TITLE
feat: enable theme switcher

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import HomeIcon from "../icons/HomeIcon.astro";
+import ThemeToggle from "./ThemeToggle.astro";
 
 const navItems = [
     {
@@ -47,10 +48,9 @@ const navItems = [
                 ))
             }
         </div>
-        <!-- TODO: Add ThemeToggle component -->
-        <!-- <div class="ml-2">
+        <div class="ml-2">
             <ThemeToggle />
-        </div> -->
+        </div>
     </nav>
 
     <script>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,6 @@
 export default {
-	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+        darkMode: 'class',
+        content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {
 			animation: {


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode
- render theme toggle in header for switching between light, dark and system preferences

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68946f85db28832c8d4a7f9c1468e079