### PR TITLE
feat: add multilingual support

### DIFF
--- a/public/i18n.js
+++ b/public/i18n.js
@@ -1,0 +1,36 @@
+const SUPPORTED_LANGS = ['en','es','fr','de','it'];
+
+function getNested(obj, key) {
+  return key.split('.').reduce((o, k) => (o || {})[k], obj);
+}
+
+async function loadLang(lang) {
+  if (!SUPPORTED_LANGS.includes(lang)) lang = 'en';
+  const res = await fetch(`/locales/${lang}.json`);
+  const data = await res.json();
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.dataset.i18n;
+    const text = getNested(data, key);
+    if (text) {
+      el.innerHTML = text;
+    }
+  });
+  document.documentElement.lang = lang;
+}
+
+function initLang() {
+  let lang = localStorage.getItem('lang') || navigator.language.slice(0,2);
+  if (!SUPPORTED_LANGS.includes(lang)) lang = 'en';
+  const selector = document.getElementById('language-selector');
+  if (selector) {
+    selector.value = lang;
+    selector.addEventListener('change', e => {
+      const newLang = e.target.value;
+      localStorage.setItem('lang', newLang);
+      loadLang(newLang);
+    });
+  }
+  loadLang(lang);
+}
+
+initLang();

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -1,0 +1,64 @@
+{
+  "nav": {
+    "experience": "Erfahrung",
+    "projects": "Projekte",
+    "about": "Über mich",
+    "contact": "Kontakt"
+  },
+  "badge": {
+    "available": "Verfügbar für die Arbeit"
+  },
+  "hero": {
+    "hello": "Hallo! Ich bin",
+    "description": "Backend und Full Stack Developer in Pamplona, Spanien 🇪🇸. Leidenschaft für Technologie, Innovation und Design. Verpflichtet, außergewöhnliche Erfahrungen und kreative Lösungen zu schaffen."
+  },
+  "section": {
+    "experience": "Berufserfahrung",
+    "projects": "Projekte",
+    "about": "Über mich"
+  },
+  "about": {
+    "content": "Ich bin <strong> mikel echeverria </strong>, ein <strong> voller Stapelentwickler </strong> und <strong> Backend </strong> mit herausragenden Fähigkeiten bei der Lösung von Problemen, der Teamarbeit und der effektiven Kommunikation </strong>. Ich habe eine tiefe Leidenschaft für die <strong> künstliche Intelligenz </strong> und die <strong> generativen Modelle </strong> Bereiche, in denen ich umfangreiches Wissen habe und für die ich persönliche Projekte entwickelt habe. Meine Erfahrung in diesen Technologien ermöglicht es mir, innovative Lösungen bereitzustellen, die Prozesse optimieren und die Effizienz verbessern. Darüber hinaus bleibe ich in ständigem Lernen, um mit den neuesten technologischen Trends auf dem neuesten Stand zu sein und daher positiv zu herausfordernden Projekten wie <strong> Developer Frontend </strong> und <strong> Backend </strong> beizutragen."
+  },
+  "experience": {
+    "moreInfo": "Weitere Informationen",
+    "codetec": {
+      "date": "Januar 2025 - Nachrichten",
+      "title": "Voller Stapelentwickler | Codetec servicios informicos sl",
+      "description": "Arbeiten Sie als vollständiger Stapelentwickler in Codetec an der Entwicklung und Wartung von Geschäftslösungen, die sich auf Management-, Buchhaltungs-, Abrechnungs- und Logistiksysteme spezialisiert haben. Ich verwende moderne Technologien wie Vue.js, Ionic, Angular und Node.js, um effiziente Web- und mobile Anwendungen zu erstellen, die die Geschäftsprozesse unserer Kunden verbessern. Meine Arbeit deckt sowohl die Grenz- als auch die Backend -Entwicklung ab und implementiert personalisierte Lösungen mit modernen Rahmenbedingungen und SQL/NOSQL -Datenbanken, die sich an die spezifischen Anforderungen jedes Unternehmens anpassen."
+    },
+    "tesicnor_backend": {
+      "date": "August 2024 - Oktober 2024",
+      "title": "Backend -Entwickler | Tesicnor SL, Noain, Navarra",
+      "description": "Als Backend -Entwickler arbeiten Sie unter anderem in der Gestaltung und Entwicklung von Webanwendungen mit Spring Boot für das Backend und verwenden unter anderem Technologien wie JSF, Git, Maven, MySQL. Darüber hinaus habe ich Erfahrungen in der vollständigen Stapelentwicklung gesammelt, wobei ich mich auf die Backend- und Relational -Datenbanken konzentriert habe."
+    },
+    "camp": {
+      "date": "Sommer 2024",
+      "title": "Camp Counselor | Camp Lonhororn Inks Lake, Texas",
+      "description": "Ich hatte die Möglichkeit, mein englisches Niveau durch totales Eintauchen in eine englischsprachige Umgebung erheblich zu verbessern. Ich leitete und beaufsichtigte Gruppen von Kindern in verschiedenen Aktivitäten und förderte eine sichere und positive Atmosphäre. Darüber hinaus erhielt ich den Geräteabschluss (Rettungsschwimmer), der es mir ermöglichte, die Sicherheit bei aquatischen Aktivitäten zu gewährleisten."
+    },
+    "tesicnor_intern": {
+      "date": "Januar 2024 - Mai 2024",
+      "title": "Praktiziert Backend Developer | Tesicnor SL, Noain, Navarra",
+      "description": "Als Backend -Entwickler habe ich an der Gestaltung und Entwicklung von Webanwendungen gearbeitet, indem ich Spring Boot für das Backend and Angular for the Frontend mithilfe des Frontends übernommen habe. Darüber hinaus habe ich praktische Erfahrungen in der vollständigen Stapelentwicklung gesammelt, wobei der Schwerpunkt auf den Backend- und Relational -Datenbanken wie MySQL liegt."
+    },
+    "burlada": {
+      "date": "März 2022 - Juni 2022",
+      "title": "Praktikum in Praktiken | Stadtrat von Burlada",
+      "description": "Während meiner Praxis in der Stadt Burlada als Computer sammelte ich Erfahrung in der Problemlösung und der Teamarbeit. Ich trug zur Entwicklung von kommunalen Computersystemen bei, arbeitete mit Fachleuten zusammen und stärkte meine Leidenschaft für Informatik und das technologische Bereich."
+    }
+  },
+  "projectsSection": {
+    "demo": "Demo",
+    "viewDemo": "Siehe Demo",
+    "viewOnGitHub": "Siehe in Github",
+    "moreProjects": "Weitere Projekte sehen",
+    "githubDescription": "Ein Github -Repository namens {{repo}}"
+  },
+  "footer": {
+    "rights": "Alle Rechte vorbehalten",
+    "source": "Quellcode",
+    "about": "Über mich",
+    "contact": "Kontakt"
+  }
+}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,0 +1,64 @@
+{
+  "nav": {
+    "experience": "Experience",
+    "projects": "Projects",
+    "about": "About me",
+    "contact": "Contact"
+  },
+  "badge": {
+    "available": "Available to work"
+  },
+  "hero": {
+    "hello": "Hi! I'm",
+    "description": "Backend and Full Stack developer in Pamplona, Spain 🇪🇸. Passionate about technology, innovation and design. Committed to creating exceptional experiences and creative solutions."
+  },
+  "section": {
+    "experience": "Work experience",
+    "projects": "Projects",
+    "about": "About me"
+  },
+  "about": {
+    "content": "I am <strong> Mikel Echeverria </strong>, a <strong> Full Stack developer </strong> and <strong> backend </strong> with prominent skills in <strong> problem solving, teamwork and effective communication </strong>. I have a deep passion for the <strong> artificial intelligence </strong> and the <strong> generative models </strong>, areas in which I have extensive knowledge and for which I have developed personal projects. My experience in these technologies allows me to provide innovative solutions that optimize processes and improve efficiency. In addition, I remain in constant learning to be up to date with the latest technological trends and thus contribute positively to challenging projects such as <strong> developer Frontend </strong> and <strong> backend </strong>."
+  },
+  "experience": {
+    "moreInfo": "More information",
+    "codetec": {
+      "date": "January 2025 - News",
+      "title": "Full Stack developer | CODETEC SERVICIOS INFORMICOS SL",
+      "description": "As a Full Stack developer in Codetec, work in the development and maintenance of business solutions, specializing in management, accounting, billing and logistics systems. I use modern technologies such as Vue.js, ionic, angular and node.js to create efficient web and mobile applications that improve our customers' business processes. My work covers both the Border and Backend development, implementing personalized solutions with modern frameworks and SQL/NOSQL databases that adapt to the specific needs of each company."
+    },
+    "tesicnor_backend": {
+      "date": "August 2024 - October 2024",
+      "title": "Backend developer | Tesicnor SL, Noain, Navarra",
+      "description": "As a backend developer, work in the design and development of web applications using Spring Boot for the Backend in addition to using technologies such as JSF, Git, Maven, MySQL, among others. In addition, I have acquired experience in Full Stack development, with emphasis on the backend and relational databases."
+    },
+    "camp": {
+      "date": "Summer 2024",
+      "title": "Camp Counselor | Camp Lonhororn Inks Lake, Texas",
+      "description": "I had the opportunity to significantly improve my English level through total immersion in an English -speaking environment. I guided and supervised groups of children in various activities, promoting a safe and positive atmosphere. In addition, I obtained the Device Degree (Lifeguard), which allowed me to guarantee security in aquatic activities."
+    },
+    "tesicnor_intern": {
+      "date": "January 2024 - May 2024",
+      "title": "Practices Backend developer | Tesicnor SL, Noain, Navarra",
+      "description": "As a backend developer, I worked on the design and development of web applications using Spring Boot for the Backend and Angular for the Frontend. In addition, I acquired practical experience in Full Stack development, with emphasis on the backend and relational databases such as MySQL."
+    },
+    "burlada": {
+      "date": "March 2022 - June 2022",
+      "title": "Internship in practices | Burlada City Council",
+      "description": "During my practices in the City of Burlada as a computer, I acquired experience in problem solving and teamwork. I contributed to the development of municipal computer systems, collaborating with professionals and strengthening my passion for computer science and the technological field."
+    }
+  },
+  "projectsSection": {
+    "demo": "Demo",
+    "viewDemo": "See demo",
+    "viewOnGitHub": "See in Github",
+    "moreProjects": "See more projects",
+    "githubDescription": "A github repository called {{repo}}"
+  },
+  "footer": {
+    "rights": "All rights reserved",
+    "source": "Source Code",
+    "about": "About me",
+    "contact": "Contact"
+  }
+}

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -1,0 +1,64 @@
+{
+  "nav": {
+    "experience": "Experiencia",
+    "projects": "Proyectos",
+    "about": "Sobre mí",
+    "contact": "Contacto"
+  },
+  "badge": {
+    "available": "Disponible para trabajar"
+  },
+  "hero": {
+    "hello": "Hola! soy",
+    "description": "Desarrollador Backend y Full Stack en Pamplona, España 🇪🇸. Apasionado por la tecnología, innovación y el diseño. Comprometido en crear experiencias excepcionales y soluciones creativas."
+  },
+  "section": {
+    "experience": "Experiencia laboral",
+    "projects": "Proyectos",
+    "about": "Sobre mí"
+  },
+  "about": {
+    "content": "Soy <strong>Mikel Echeverria</strong>, un <strong>Desarrollador Full Stack</strong> y <strong>Backend</strong> con habilidades destacadas en <strong>resolución de problemas, trabajo en equipo y comunicación efectiva</strong>. Tengo una profunda pasión por la <strong>Inteligencia Artificial</strong> y los <strong>modelos generativos</strong>, áreas en las que poseo un amplio conocimiento y para las cuales he desarrollado proyectos personales. Mi experiencia en estas tecnologías me permite aportar soluciones innovadoras que optimizan procesos y mejoran la eficiencia. Además, me mantengo en constante aprendizaje para estar al día con las últimas tendencias tecnológicas y así contribuir positivamente en proyectos desafiantes como <strong>desarrollador Frontend</strong> y <strong>Backend</strong>."
+  },
+  "experience": {
+    "moreInfo": "Más información",
+    "codetec": {
+      "date": "Enero 2025 - Actualidad",
+      "title": "Desarrollador Full Stack | Codetec Servicios Informaticos SL",
+      "description": "Como Desarrollador Full Stack en Codetec, trabajo en el desarrollo y mantenimiento de soluciones empresariales, especializándome en sistemas de gestión, contabilidad, facturación y logística. Utilizo tecnologías modernas como Vue.js, Ionic, Angular y Node.js para crear aplicaciones web y móviles eficientes que mejoran los procesos de negocio de nuestros clientes. Mi trabajo abarca tanto el desarrollo frontend como backend, implementando soluciones personalizadas con frameworks modernos y bases de datos SQL/NoSQL que se adaptan a las necesidades específicas de cada empresa."
+    },
+    "tesicnor_backend": {
+      "date": "Agosto 2024 - Octubre 2024",
+      "title": "Desarrollador Backend | Tesicnor SL, Noain, Navarra",
+      "description": "Como Desarrollador Backend, trabajo en el diseño y desarrollo de aplicaciones web utilizando Spring Boot para el backend además de utilizar tecnologías como JSF, Git, Maven, MySQL, entre otras. Además, he adquirido experiencia en el desarrollo full stack, con énfasis en el backend y bases de datos relacionales."
+    },
+    "camp": {
+      "date": "Verano 2024",
+      "title": "Camp Counselor | Camp Longhorn Inks Lake, Texas",
+      "description": "Tuve la oportunidad de mejorar significativamente mi nivel de inglés a través de la inmersión total en un entorno de habla inglesa. Guié y supervisé a grupos de niños en diversas actividades, fomentando un ambiente seguro y positivo. Además, obtuve la titulación de socorrista (lifeguard), lo que me permitió garantizar la seguridad en actividades acuáticas."
+    },
+    "tesicnor_intern": {
+      "date": "Enero 2024 - Mayo 2024",
+      "title": "Desarrollador Backend en Prácticas | Tesicnor SL, Noain, Navarra",
+      "description": "Como Desarrollador Backend, trabajé en el diseño y desarrollo de aplicaciones web utilizando Spring Boot para el backend y Angular para el frontend. Además, adquirí experiencia práctica en el desarrollo full stack, con énfasis en el backend y bases de datos relacionales como MySQL."
+    },
+    "burlada": {
+      "date": "Marzo 2022 - Junio 2022",
+      "title": "Informático en Prácticas | Ayuntamiento de Burlada",
+      "description": "Durante mis prácticas en el Ayuntamiento de Burlada como informático, adquirí experiencia en resolución de problemas y trabajo en equipo. Contribuí al desarrollo de sistemas informáticos municipales, colaborando con profesionales y fortaleciendo mi pasión por la informática y el campo tecnológico."
+    }
+  },
+  "projectsSection": {
+    "demo": "DEMO",
+    "viewDemo": "Ver demo",
+    "viewOnGitHub": "Ver en GitHub",
+    "moreProjects": "Ver más proyectos",
+    "githubDescription": "Un repositorio de GitHub llamado {{repo}}"
+  },
+  "footer": {
+    "rights": "Todos los derechos reservados",
+    "source": "Código fuente",
+    "about": "Sobre mí",
+    "contact": "Contacto"
+  }
+}

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -1,0 +1,64 @@
+{
+  "nav": {
+    "experience": "Expérience",
+    "projects": "Projets",
+    "about": "Sur moi",
+    "contact": "Contact"
+  },
+  "badge": {
+    "available": "Disponible pour travailler"
+  },
+  "hero": {
+    "hello": "Bonjour ! Je suis",
+    "description": "Backend et développeur complet à Pampelune, Espagne 🇪🇸. Passionné par la technologie, l'innovation et le design. Engagé à créer des expériences exceptionnelles et des solutions créatives."
+  },
+  "section": {
+    "experience": "Expérience de travail",
+    "projects": "Projets",
+    "about": "Sur moi"
+  },
+  "about": {
+    "content": "Je suis <strong> Mikel Echeverria </strong>, un <strong> développeur de pile complet </strong> et <strong> backend </strong> avec des compétences éminentes dans la résolution de problèmes <strong>, le travail d'équipe et la communication efficace </strong>. J'ai une profonde passion pour l'intelligence artificielle <strong> </strong> et les modèles génératifs <strong> </strong>, les domaines dans lesquels j'ai des connaissances approfondies et pour lesquelles j'ai développé des projets personnels. Mon expérience dans ces technologies me permet de fournir des solutions innovantes qui optimisent les processus et améliorent l'efficacité. De plus, je reste constamment en apprenant à être à jour avec les dernières tendances technologiques et contribue donc positivement à des projets difficiles tels que <strong> développeur frontend </strong> et <strong> backend </strong>."
+  },
+  "experience": {
+    "moreInfo": "Plus d'informations",
+    "codetec": {
+      "date": "Janvier 2025 - News",
+      "title": "Développeur de pile complet | Codetec Servicios Informecos sl",
+      "description": "En tant que développeur complet de la pile dans Codetec, travaillez dans le développement et la maintenance des solutions commerciales, spécialisés dans les systèmes de gestion, de comptabilité, de facturation et de logistique. J'utilise des technologies modernes telles que Vue.js, Ionic, Angular et Node.js pour créer des applications Web et mobiles efficaces qui améliorent les processus commerciaux de nos clients. Mon travail couvre à la fois le développement de la frontière et du backend, mettant en œuvre des solutions personnalisées avec des frameworks modernes et des bases de données SQL / NOSQL qui s'adaptent aux besoins spécifiques de chaque entreprise."
+    },
+    "tesicnor_backend": {
+      "date": "Août 2024 - octobre 2024",
+      "title": "Développeur backend | Tesicnor Sl, Noain, Navarra",
+      "description": "En tant que développeur backend, travaillez dans la conception et le développement d'applications Web utilisant Spring Boot pour le backend en plus d'utiliser des technologies telles que JSF, GIT, Maven, MySQL, entre autres. De plus, j'ai acquis une expérience dans le développement complet de la pile, en mettant l'accent sur les bases de données backend et relationnelles."
+    },
+    "camp": {
+      "date": "Été 2024",
+      "title": "Conseiller du camp | Camp Lonhororn Inks Lake, Texas",
+      "description": "J'ai eu l'occasion d'améliorer considérablement mon niveau anglais grâce à une immersion totale dans un environnement en anglais. J'ai guidé et supervisé des groupes d'enfants dans diverses activités, faisant la promotion d'une atmosphère sûre et positive. De plus, j'ai obtenu le degré de dispositif (sauveteur), ce qui m'a permis de garantir la sécurité dans les activités aquatiques."
+    },
+    "tesicnor_intern": {
+      "date": "Janvier 2024 - mai 2024",
+      "title": "Pratiques Développeur backend | Tesicnor Sl, Noain, Navarra",
+      "description": "En tant que développeur backend, j'ai travaillé sur la conception et le développement d'applications Web en utilisant Spring Boot pour le backend et Angular pour le frontend. De plus, j'ai acquis une expérience pratique dans le développement complet de la pile, en mettant l'accent sur les bases de données backend et relationnelles telles que MySQL."
+    },
+    "burlada": {
+      "date": "Mars 2022 - juin 2022",
+      "title": "Stage dans les pratiques | Conseil municipal de Burlada",
+      "description": "Au cours de mes entraînements dans la ville de Burlada en tant qu'ordinateur, j'ai acquis une expérience dans la résolution de problèmes et le travail d'équipe. J'ai contribué au développement de systèmes informatiques municipaux, à collaborer avec des professionnels et à renforcer ma passion pour l'informatique et le domaine technologique."
+    }
+  },
+  "projectsSection": {
+    "demo": "Démo",
+    "viewDemo": "Voir la démo",
+    "viewOnGitHub": "Voir dans github",
+    "moreProjects": "Voir plus de projets",
+    "githubDescription": "Un référentiel GitHub appelé {{repo}}"
+  },
+  "footer": {
+    "rights": "Tous droits réservés",
+    "source": "Code source",
+    "about": "Sur moi",
+    "contact": "Contact"
+  }
+}

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -1,0 +1,64 @@
+{
+  "nav": {
+    "experience": "Esperienza",
+    "projects": "Progetti",
+    "about": "Su di me",
+    "contact": "Contatto"
+  },
+  "badge": {
+    "available": "Disponibile per il lavoro"
+  },
+  "hero": {
+    "hello": "Ciao! Sono",
+    "description": "Sviluppatore di back -end e full stack a Pamplona, Spagna 🇪🇸. Appassionato di tecnologia, innovazione e design. Impegnato a creare esperienze eccezionali e soluzioni creative."
+  },
+  "section": {
+    "experience": "Esperienza di lavoro",
+    "projects": "Progetti",
+    "about": "Su di me"
+  },
+  "about": {
+    "content": "Sono <strong> mikel echeverria </strong>, uno sviluppatore di stack completo </strong> e <strong> backend </strong> con abilità importanti in <strong> risoluzione di problemi, lavoro di squadra e comunicazione efficace </strong>. Ho una profonda passione per l'intelligenza artificiale </strong> e i modelli generativi <strong> </strong>, aree in cui ho ampie conoscenze e per le quali ho sviluppato progetti personali. La mia esperienza in queste tecnologie mi consente di fornire soluzioni innovative che ottimizzano i processi e migliorano l'efficienza. Inoltre, rimango in costante apprendimento per essere aggiornato con le ultime tendenze tecnologiche e quindi contribuisco positivamente a progetti impegnativi come <strong> sviluppatore frontend </strong> e <strong> backend </strong>."
+  },
+  "experience": {
+    "moreInfo": "Maggiori informazioni",
+    "codetec": {
+      "date": "Gennaio 2025 - Notizie",
+      "title": "Sviluppatore di stack completo | COdetec Servicios Informicos SL",
+      "description": "Come sviluppatore di stack completo in Codetec, lavorare nello sviluppo e nella manutenzione di soluzioni aziendali, specializzate in sistemi di gestione, contabilità, fatturazione e logistica. Uso tecnologie moderne come vue.js, ionic, angolare e node.js per creare applicazioni Web e mobili efficienti che migliorano i processi aziendali dei nostri clienti. Il mio lavoro copre sia lo sviluppo di confine che backend, implementando soluzioni personalizzate con framework moderni e database SQL/NOSQL che si adattano alle esigenze specifiche di ciascuna azienda."
+    },
+    "tesicnor_backend": {
+      "date": "Agosto 2024 - ottobre 2024",
+      "title": "Sviluppatore di backend | Tesicnor SL, Noain, Navarra",
+      "description": "Come sviluppatore di back -end, lavora nella progettazione e nello sviluppo di applicazioni Web utilizzando Spring Boot per il backend oltre a utilizzare tecnologie come JSF, Git, Maven, Mysql, tra gli altri. Inoltre, ho acquisito esperienza in completa sviluppo dello stack, con enfasi sui database back -end e relazionali."
+    },
+    "camp": {
+      "date": "Estate 2024",
+      "title": "Consigliere del campo | Camp Lonhororn Inks Lake, Texas",
+      "description": "Ho avuto l'opportunità di migliorare in modo significativo il mio livello inglese attraverso l'immersione totale in un ambiente di dispersione in inglese. Ho guidato e supervisionato gruppi di bambini in varie attività, promuovendo un'atmosfera sicura e positiva. Inoltre, ho ottenuto la laurea in dispositivo (bagnino), che mi ha permesso di garantire la sicurezza nelle attività acquatiche."
+    },
+    "tesicnor_intern": {
+      "date": "Gennaio 2024 - maggio 2024",
+      "title": "Pratiche Sviluppatore di backend | Tesicnor SL, Noain, Navarra",
+      "description": "Come sviluppatore di back -end, ho lavorato alla progettazione e allo sviluppo di applicazioni Web utilizzando Spring Boot per il backend e Angular per il frontend. Inoltre, ho acquisito esperienza pratica in completa sviluppo dello stack, con enfasi sui database back -end e relazionali come MySQL."
+    },
+    "burlada": {
+      "date": "Marzo 2022 - giugno 2022",
+      "title": "Stage in pratiche | Consiglio comunale di Burlada",
+      "description": "Durante le mie pratiche nella città di Burlada come computer, ho acquisito esperienza nella risoluzione dei problemi e nel lavoro di squadra. Ho contribuito allo sviluppo di sistemi informatici municipali, collaborando con professionisti e rafforzando la mia passione per l'informatica e il campo tecnologico."
+    }
+  },
+  "projectsSection": {
+    "demo": "Demo",
+    "viewDemo": "Vedi demo",
+    "viewOnGitHub": "Vedi in GitHub",
+    "moreProjects": "Vedi altri progetti",
+    "githubDescription": "Un repository GitHub chiamato {{Repo}}"
+  },
+  "footer": {
+    "rights": "Tutti i diritti riservati",
+    "source": "Codice sorgente",
+    "about": "Su di me",
+    "contact": "Contatto"
+  }
+}

--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -10,7 +10,7 @@ const personalImageAlt = "Mikel Echeverria, Desarrollador Full Stack y Backend";
   <div
     class="text-pretty order-2 md:order-1"
   >
-    <p>
+    <p data-i18n="about.content">
       Soy <strong>Mikel Echeverria</strong>, un <strong>Desarrollador Full Stack</strong> y <strong>Backend</strong> con habilidades destacadas en <strong>resolución de problemas, trabajo en equipo y comunicación efectiva</strong>. Tengo una profunda pasión por la <strong>Inteligencia Artificial</strong> y los <strong>modelos generativos</strong>, áreas en las que poseo un amplio conocimiento y para las cuales he desarrollado proyectos personales. Mi experiencia en estas tecnologías me permite aportar soluciones innovadoras que optimizan procesos y mejoran la eficiencia. Además, me mantengo en constante aprendizaje para estar al día con las últimas tendencias tecnológicas y así contribuir positivamente en proyectos desafiantes como <strong>desarrollador Frontend</strong> y <strong>Backend</strong>.
     </p>
   </div>

--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -7,9 +7,12 @@ export interface ExperienceItemProps {
     date: string;
     link: string;
     isFirst?: boolean;
+    titleKey?: string;
+    descriptionKey?: string;
+    dateKey?: string;
 }
 
-const { title, description, date, link, isFirst } =
+const { title, description, date, link, isFirst, titleKey, descriptionKey, dateKey } =
     Astro.props as ExperienceItemProps;
 ---
 <div
@@ -18,14 +21,16 @@ const { title, description, date, link, isFirst } =
 </div>
 <span
     class={`${isFirst ? "text-xl font-bold text-zinc-800 dark:text-zinc-200" : ""} mb-1 text-sm font-normal leading-none text-zinc-600 dark:text-zinc-400`}
+    data-i18n={dateKey}
 >
     {date}
 </span>
-<h3 class="text-lg font-semibold text-zinc-900 dark:text-white">
+<h3 class="text-lg font-semibold text-zinc-900 dark:text-white" data-i18n={titleKey}>
     {title}
 </h3>
 <p
     class="mb-4 text-base font-normal text-zinc-700 dark:text-zinc-300 text-pretty"
+    data-i18n={descriptionKey}
 >
     {description}
 </p>
@@ -37,7 +42,7 @@ const { title, description, date, link, isFirst } =
             rel="noopener noreferrer"
             class="inline-flex items-center px-4 py-2 text-sm font-medium text-zinc-900 bg-white border border-zinc-200 rounded-lg hover:bg-zinc-100  focus:z-10 focus:ring-4 focus:outline-none focus:ring-zinc-100 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-600 dark:hover:text-white dark:hover:bg-zinc-700 dark:focus:ring-zinc-700"
         >
-            Más información
+            <span data-i18n="experience.moreInfo">Más información</span>
             <ArrowIcon />
         </a>
     )

--- a/src/components/Experiences.astro
+++ b/src/components/Experiences.astro
@@ -2,54 +2,61 @@
 import ExperienceItem from "./ExperienceItem.astro";
 
 const EXPERIENCES = [
-    {
-        date: "Enero 2025 - Actualidad",
-        title: "Desarrollador Full Stack | Codetec Servicios Informaticos SL",
-        description: `Como Desarrollador Full Stack en Codetec, trabajo en el desarrollo y mantenimiento de soluciones empresariales, especializándome en sistemas de gestión, contabilidad, facturación y logística. Utilizo tecnologías modernas como Vue.js, Ionic, Angular y Node.js para crear aplicaciones web y móviles eficientes que mejoran los procesos de negocio de nuestros clientes. Mi trabajo abarca tanto el desarrollo frontend como backend, implementando soluciones personalizadas con frameworks modernos y bases de datos SQL/NoSQL que se adaptan a las necesidades específicas de cada empresa.`,
-        link: "https://www.codetec.es/",
-        isFirst: true,
-    },
-    {
-        date: "Agosto 2024 - Octubre 2024",
-        title: "Desarrollador Backend | Tesicnor SL, Noain, Navarra",
-        description: `Como Desarrollador Backend, trabajo en el diseño y desarrollo de aplicaciones web utilizando Spring Boot para el backend además de utilizar tecnologías como JSF, Git, Maven, MySQL, entre otras. Además, he adquirido experiencia en el desarrollo full stack, con énfasis en el backend y bases de datos relacionales.`,
-        link: "https://www.tesicnor.com/",
-    },
-    {
-        date: "Verano 2024",
-        title: "Camp Counselor | Camp Longhorn Inks Lake, Texas",
-        description: `Tuve la oportunidad de mejorar significativamente mi nivel de inglés a través de la
-inmersión total en un entorno de habla inglesa. Guié y supervisé a grupos de niños en
-diversas actividades, fomentando un ambiente seguro y positivo. Además, obtuve la
-titulación de socorrista (lifeguard), lo que me permitió garantizar la seguridad en
-actividades acuáticas.`,
-        link: "https://www.camplonghorn.com/",
-    },
-    {
-        date: "Enero 2024 - Mayo 2024",
-        title: "Desarrollador Backend en Prácticas | Tesicnor SL, Noain, Navarra",
-        description: `
-        Como Desarrollador Backend, trabajé en el diseño y desarrollo de aplicaciones web utilizando Spring Boot para el backend y Angular para el frontend. Además, adquirí experiencia práctica en el desarrollo full stack, con énfasis en el backend y bases de datos relacionales como MySQL.`,
-        link: "https://www.tesicnor.com/",
-    },
-    {
-        date: "Marzo 2022 - Junio 2022",
-        title: "Informático en Prácticas | Ayuntamiento de Burlada",
-        description: `Durante mis prácticas en el Ayuntamiento de Burlada como informático, adquirí
-experiencia en resolución de problemas y trabajo en equipo. Contribuí al desarrollo de
-sistemas informáticos municipales, colaborando con profesionales y fortaleciendo mi
-pasión por la informática y el campo tecnológico.`,
-        link: "https://www.burlada.es/",
-    },
+  {
+    date: "Enero 2025 - Actualidad",
+    dateKey: "experience.codetec.date",
+    title: "Desarrollador Full Stack | Codetec Servicios Informaticos SL",
+    titleKey: "experience.codetec.title",
+    description: `Como Desarrollador Full Stack en Codetec, trabajo en el desarrollo y mantenimiento de soluciones empresariales, especializándome en sistemas de gestión, contabilidad, facturación y logística. Utilizo tecnologías modernas como Vue.js, Ionic, Angular y Node.js para crear aplicaciones web y móviles eficientes que mejoran los procesos de negocio de nuestros clientes. Mi trabajo abarca tanto el desarrollo frontend como backend, implementando soluciones personalizadas con frameworks modernos y bases de datos SQL/NoSQL que se adaptan a las necesidades específicas de cada empresa.`,
+    descriptionKey: "experience.codetec.description",
+    link: "https://www.codetec.es/",
+    isFirst: true,
+  },
+  {
+    date: "Agosto 2024 - Octubre 2024",
+    dateKey: "experience.tesicnor_backend.date",
+    title: "Desarrollador Backend | Tesicnor SL, Noain, Navarra",
+    titleKey: "experience.tesicnor_backend.title",
+    description: `Como Desarrollador Backend, trabajo en el diseño y desarrollo de aplicaciones web utilizando Spring Boot para el backend además de utilizar tecnologías como JSF, Git, Maven, MySQL, entre otras. Además, he adquirido experiencia en el desarrollo full stack, con énfasis en el backend y bases de datos relacionales.`,
+    descriptionKey: "experience.tesicnor_backend.description",
+    link: "https://www.tesicnor.com/",
+  },
+  {
+    date: "Verano 2024",
+    dateKey: "experience.camp.date",
+    title: "Camp Counselor | Camp Longhorn Inks Lake, Texas",
+    titleKey: "experience.camp.title",
+    description: `Tuve la oportunidad de mejorar significativamente mi nivel de inglés a través de la inmersión total en un entorno de habla inglesa. Guié y supervisé a grupos de niños en diversas actividades, fomentando un ambiente seguro y positivo. Además, obtuve la titulación de socorrista (lifeguard), lo que me permitió garantizar la seguridad en actividades acuáticas.`,
+    descriptionKey: "experience.camp.description",
+    link: "https://www.camplonghorn.com/",
+  },
+  {
+    date: "Enero 2024 - Mayo 2024",
+    dateKey: "experience.tesicnor_intern.date",
+    title: "Desarrollador Backend en Prácticas | Tesicnor SL, Noain, Navarra",
+    titleKey: "experience.tesicnor_intern.title",
+    description: `Como Desarrollador Backend, trabajé en el diseño y desarrollo de aplicaciones web utilizando Spring Boot para el backend y Angular para el frontend. Además, adquirí experiencia práctica en el desarrollo full stack, con énfasis en el backend y bases de datos relacionales como MySQL.`,
+    descriptionKey: "experience.tesicnor_intern.description",
+    link: "https://www.tesicnor.com/",
+  },
+  {
+    date: "Marzo 2022 - Junio 2022",
+    dateKey: "experience.burlada.date",
+    title: "Informático en Prácticas | Ayuntamiento de Burlada",
+    titleKey: "experience.burlada.title",
+    description: `Durante mis prácticas en el Ayuntamiento de Burlada como informático, adquirí experiencia en resolución de problemas y trabajo en equipo. Contribuí al desarrollo de sistemas informáticos municipales, colaborando con profesionales y fortaleciendo mi pasión por la informática y el campo tecnológico.`,
+    descriptionKey: "experience.burlada.description",
+    link: "https://www.burlada.es/",
+  },
 ];
 ---
 
 <ol class="relative border-s border-gray-300 dark:border-gray-700">
-    {
-        EXPERIENCES.map((experience) => (
-            <li class="mb-10 ms-4">
-                <ExperienceItem {...experience} />
-            </li>
-        ))
-    }
+  {
+    EXPERIENCES.map((experience) => (
+      <li class="mb-10 ms-4">
+        <ExperienceItem {...experience} />
+      </li>
+    ))
+  }
 </ol>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -15,7 +15,7 @@ const currentYear = new Date().getFullYear()
         class="transition hover:text-purple-500 dark:hover:text-purple-400 dark:text-white"
         itemprop="publisher"
         >Mikel Echeverria</a
-      >. Todos los derechos reservados
+      >. <span data-i18n="footer.rights">Todos los derechos reservados</span>
     </span>
     <nav aria-label="Footer Navigation" class="w-full md:w-auto">
       <ul
@@ -26,7 +26,7 @@ const currentYear = new Date().getFullYear()
             href="https://github.mikeldev.com//portfolio-dev"
             class="transition hover:text-purple-500 dark:hover:text-purple-400 flex items-center gap-x-1"
             itemprop="sameAs"
-            > <GitHubIcon class="size-4" /> Código fuente
+            > <GitHubIcon class="size-4" /> <span data-i18n="footer.source">Código fuente</span>
           </a>
         </li>
         <li>
@@ -34,7 +34,7 @@ const currentYear = new Date().getFullYear()
             href="/#sobre-mi"
             class="transition hover:text-purple-500 dark:hover:text-purple-400"
             itemprop="about"
-            >Sobre mí</a
+            ><span data-i18n="footer.about">Sobre mí</span></a
           >
         </li>
         <li>
@@ -43,7 +43,7 @@ const currentYear = new Date().getFullYear()
             href="mailto:mikel@mikeldev.com"
             class="transition hover:text-purple-500 dark:hover:text-purple-400"
             itemprop="email"
-            >Contacto</a
+            ><span data-i18n="footer.contact">Contacto</span></a
           >
         </li>
       </ul>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,21 +5,25 @@ import ThemeToggle from "./ThemeToggle.astro";
 const navItems = [
     {
         title: "Experiencia",
+        key: "nav.experience",
         label: "experiencia",
         url: "/#experiencia",
     },
     {
         title: "Proyectos",
+        key: "nav.projects",
         label: "proyectos",
         url: "/#proyectos",
     },
     {
         title: "Sobre mí",
+        key: "nav.about",
         label: "sobre-mi",
         url: "/#sobre-mi",
     },
     {
         title: "Contacto",
+        key: "nav.contact",
         label: "contacto",
         url: "mailto:mikel@mikeldev.com",
     },
@@ -42,6 +46,7 @@ const navItems = [
                         class="relative block px-2 py-2 transition hover:text-purple-500 dark:hover:text-purple-400 text-center"
                         aria-label={link.label}
                         href={link.url}
+                        data-i18n={link.key}
                     >
                         {link.title}
                     </a>
@@ -50,6 +55,18 @@ const navItems = [
         </div>
         <div class="ml-2">
             <ThemeToggle />
+        </div>
+        <div class="ml-2">
+            <select
+                id="language-selector"
+                class="bg-transparent outline-none text-xs md:text-sm"
+            >
+                <option value="en">English</option>
+                <option value="es">Español</option>
+                <option value="fr">Français</option>
+                <option value="de">Deutsch</option>
+                <option value="it">Italiano</option>
+            </select>
         </div>
     </nav>
 

--- a/src/components/Proyects.astro
+++ b/src/components/Proyects.astro
@@ -284,7 +284,7 @@ try {
                                     <a href={link?.length ? link : github} target="_blank" rel="noopener noreferrer">
                                         {link && (
                                             <div class="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-100 transition duration-300 hover:bg-black/50">
-                                                <p class="text-white text-2xl font-bold">
+                                                <p class="text-white text-2xl font-bold" data-i18n="projectsSection.demo">
                                                     DEMO
                                                 </p>
                                             </div>
@@ -314,7 +314,7 @@ try {
                                             class="opacity-80 hover:opacity-100 transition hover:text-purple-500 dark:hover:text-purple-400 flex items-center gap-x-1"
                                         >
                                             <DesktopIcon class="size-6" />
-                                            Ver demo
+        <span data-i18n="projectsSection.viewDemo">Ver demo</span>
                                         </a>
                                     )}
                                     {github && (
@@ -325,7 +325,7 @@ try {
                                             class="dark:text-white transition hover:text-purple-500 dark:hover:text-purple-400 flex items-center gap-x-1 opacity-80 hover:opacity-100"
                                         >
                                             <GitHubIcon class="size-6" />
-                                            Ver en GitHub
+        <span data-i18n="projectsSection.viewOnGitHub">Ver en GitHub</span>
                                         </a>
                                     )}
                                 </div>
@@ -336,7 +336,7 @@ try {
             )}
             {PROYECTS.length > 6 && (
                 <div class="flex justify-center col-span-1 sm:col-span-2 px-4">
-                    <SocialPill href="?tab=repositories">
+                    <SocialPill href="?tab=repositories" data-i18n="projectsSection.moreProjects">
                         Ver más proyectos
                     </SocialPill>
                 </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const { description, title } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="es">
+<html lang="en">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="description" content={description} />
@@ -95,11 +95,12 @@ const { description, title } = Astro.props;
 		</script>
 		<title>{title}</title>
 	</head>
-	<body>
-		<Background />
-		<Header />
-		<slot />
-	</body>
+        <body>
+                <Background />
+                <Header />
+                <slot />
+                <script src="/i18n.js" is:inline></script>
+        </body>
 </html>
 <style is:global>
 	:root {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,39 +37,30 @@ import myPhoto from "/public/photo.webp";
 			<div
 				class="flex flex-col lg:flex-row gap-x-4 items-center sm:items-start"
 			>
-				<h1
-					class="text-3xl sm:text-4xl font-bold mb-4 text-center sm:text-left lg:mt-9"
-				>
-					Hola! soy <TextAnimatedGradient fontSize="inherit"
-						>Mikel</TextAnimatedGradient
-					>
-				</h1>
+                                <h1
+                                        class="text-3xl sm:text-4xl font-bold mb-4 text-center sm:text-left lg:mt-9"
+                                >
+                                        <span data-i18n="hero.hello">Hola! soy</span>
+                                        <TextAnimatedGradient fontSize="inherit"
+                                                >Mikel</TextAnimatedGradient
+                                        >
+                                </h1>
 				<a
 					href="https://www.linkedin.com/in/mikel-echeverria"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="lg:mt-11"
-				>
-					<Badge>Disponible para trabajar</Badge>
-				</a>
+                                        class="lg:mt-11"
+                                >
+                                        <Badge data-i18n="badge.available">Disponible para trabajar</Badge>
+                                </a>
 			</div>
 		</div>
 
-		<h2
-			class="text-xl sm:text-2xl text-wrap mt-4 sm:mt-0 text-center sm:text-left"
-		>
-			<span class="opacity-80"
-				>Desarrollador</span> Backend <span class="opacity-80">y</span> Full Stack <span class="opacity-80">en Pamplona, España 🇪🇸. Apasionado por la
-				tecnología,</span
-			> innovación
-			<span class="opacity-80">y el</span> diseño
-			<span class="opacity-80"
-				>. Comprometido en crear experiencias
-			</span>
-			excepcionales
-			<span class="opacity-80">y soluciones </span>
-			creativas.
-		</h2>
+                <h2
+                        class="text-xl sm:text-2xl text-wrap mt-4 sm:mt-0 text-center sm:text-left"
+                >
+                        <span data-i18n="hero.description">Desarrollador Backend y Full Stack en Pamplona, España 🇪🇸. Apasionado por la tecnología, innovación y el diseño. Comprometido en crear experiencias excepcionales y soluciones creativas.</span>
+                </h2>
 
 		<ul class="flex flex-wrap justify-center sm:justify-start gap-4 mt-8">
 			<li>
@@ -110,26 +101,26 @@ import myPhoto from "/public/photo.webp";
 	</SectionContainer>
 
 	<SectionContainer class="py-16 sm:py-32">
-		<h2 id="experiencia" class="text-2xl font-bold mb-6 flex gap-x-2">
-			<BriefcaseIcon class="size-7" />
-			Experiencia laboral
-		</h2>
+                <h2 id="experiencia" class="text-2xl font-bold mb-6 flex gap-x-2" data-i18n="section.experience">
+                        <BriefcaseIcon class="size-7" />
+                        Experiencia laboral
+                </h2>
 		<Experiences />
 	</SectionContainer>
 
 	<SectionContainer class="py-16 sm:py-32 lg:py-44">
-		<h2 id="proyectos" class="text-2xl font-bold mb-6 flex gap-x-2">
-			<Code class="size-7" />
-			Proyectos
-		</h2>
+                <h2 id="proyectos" class="text-2xl font-bold mb-6 flex gap-x-2" data-i18n="section.projects">
+                        <Code class="size-7" />
+                        Proyectos
+                </h2>
 		<Proyects />
 	</SectionContainer>
 
 	<SectionContainer>
-		<h2 id="sobre-mi" class="text-2xl font-bold mb-6 flex gap-x-2">
-			<ProfileCheck class="size-7" />
-			Sobre mí
-		</h2>
+                <h2 id="sobre-mi" class="text-2xl font-bold mb-6 flex gap-x-2" data-i18n="section.about">
+                        <ProfileCheck class="size-7" />
+                        Sobre mí
+                </h2>
 		<AboutMe />
 	</SectionContainer>
 


### PR DESCRIPTION
## Summary
- add translation loader with auto-detection and user selector
- translate site content into English, Spanish, French, German and Italian
- wire translations through header and main sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894790c8714832cb389205db8bf1b6f