### PR TITLE
fix: ajustar clase del menú de navegación para mejorar la responsividad

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -36,7 +36,7 @@ const navItems = [
     class="fixed top-0 z-10 flex items-center justify-center w-full mx-auto mt-2"
 >
     <nav
-        class="flex px-3 text-xs md:text-sm font-medium rounded-full text-gray-800 dark:text-gray-200 justify-center items-center w-full"
+        class="flex px-3 text-xs md:text-sm font-medium rounded-full text-gray-800 dark:text-gray-200 justify-center items-center w-full md:w-auto"
     >
         <div class="mr-2 hover:scale-125 transition">
             <HomeIcon />


### PR DESCRIPTION
This pull request makes a minor adjustment to the navigation bar's styling in the `Header.astro` component. The main change is to allow the navigation bar's width to be responsive on medium-sized screens and above.

- Updated the navigation bar's CSS classes to use `w-full md:w-auto`, making the navigation bar full width on small screens and auto width on medium and larger screens.