### PR TITLE
refactor: improve multilingual translations

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -6,11 +6,11 @@
     "contact": "Kontakt"
   },
   "badge": {
-    "available": "Verfügbar für die Arbeit"
+    "available": "Verfügbar für neue Projekte"
   },
   "hero": {
     "hello": "Hallo! Ich bin",
-    "description": "Backend und Full Stack Developer in Pamplona, Spanien 🇪🇸. Leidenschaft für Technologie, Innovation und Design. Verpflichtet, außergewöhnliche Erfahrungen und kreative Lösungen zu schaffen."
+    "description": "Backend- und Full-Stack-Entwickler mit Sitz in Pamplona, Spanien 🇪🇸. Begeistert von Technologie, Innovation und Design und engagiert, außergewöhnliche Erlebnisse und kreative Lösungen zu schaffen."
   },
   "section": {
     "experience": "Berufserfahrung",
@@ -18,42 +18,42 @@
     "about": "Über mich"
   },
   "about": {
-    "content": "Ich bin <strong> mikel echeverria </strong>, ein <strong> voller Stapelentwickler </strong> und <strong> Backend </strong> mit herausragenden Fähigkeiten bei der Lösung von Problemen, der Teamarbeit und der effektiven Kommunikation </strong>. Ich habe eine tiefe Leidenschaft für die <strong> künstliche Intelligenz </strong> und die <strong> generativen Modelle </strong> Bereiche, in denen ich umfangreiches Wissen habe und für die ich persönliche Projekte entwickelt habe. Meine Erfahrung in diesen Technologien ermöglicht es mir, innovative Lösungen bereitzustellen, die Prozesse optimieren und die Effizienz verbessern. Darüber hinaus bleibe ich in ständigem Lernen, um mit den neuesten technologischen Trends auf dem neuesten Stand zu sein und daher positiv zu herausfordernden Projekten wie <strong> Developer Frontend </strong> und <strong> Backend </strong> beizutragen."
+    "content": "Ich bin <strong>Mikel Echeverria</strong>, <strong>Full-Stack-</strong> und <strong>Backend-Entwickler</strong> mit ausgeprägten Fähigkeiten in <strong>Problemlösung, Teamarbeit und effektiver Kommunikation</strong>. Ich habe eine große Leidenschaft für <strong>künstliche Intelligenz</strong> und <strong>generative Modelle</strong>, Bereiche, in denen ich über umfangreiches Wissen verfüge und persönliche Projekte realisiert habe. Meine Erfahrung mit diesen Technologien ermöglicht es mir, innovative Lösungen zu liefern, die Prozesse optimieren und Effizienz verbessern. Außerdem bilde ich mich ständig weiter, um mit den neuesten technologischen Trends Schritt zu halten und so anspruchsvolle Projekte als <strong>Frontend-</strong> und <strong>Backend-Entwickler</strong> positiv zu unterstützen."
   },
   "experience": {
-    "moreInfo": "Weitere Informationen",
+    "moreInfo": "Mehr Informationen",
     "codetec": {
-      "date": "Januar 2025 - Nachrichten",
-      "title": "Voller Stapelentwickler | Codetec servicios informicos sl",
-      "description": "Als <strong>vollständiger Stapelentwickler</strong> in Codetec arbeite ich an der Entwicklung und Wartung von <strong>Geschäftslösungen</strong>, die sich auf <strong>Management-, Buchhaltungs-, Abrechnungs- und Logistiksysteme</strong> spezialisieren. Ich verwende moderne Technologien wie <strong>Vue.js, Ionic, Angular und Node.js</strong>, um effiziente Web- und mobile Anwendungen zu erstellen, die die Geschäftsprozesse unserer Kunden verbessern. Meine Arbeit deckt sowohl die Frontend- als auch die Backend-Entwicklung ab und implementiert <strong>personalisierte Lösungen</strong> mit modernen Frameworks und SQL/NOSQL-Datenbanken, die sich an die spezifischen Anforderungen jedes Unternehmens anpassen."
+      "date": "Januar 2025 - Heute",
+      "title": "Full-Stack-Entwickler | CODETEC Servicios Informáticos SL",
+      "description": "Als <strong>Full-Stack-Entwickler</strong> bei Codetec entwickle und pflege ich <strong>Geschäftslösungen</strong> und spezialisiere mich auf <strong>Management-, Buchhaltungs-, Abrechnungs- und Logistiksysteme</strong>. Mit modernen Technologien wie <strong>Vue.js, Ionic, Angular und Node.js</strong> erstelle ich effiziente Web- und Mobilanwendungen, die die Geschäftsprozesse unserer Kunden verbessern. Meine Arbeit umfasst sowohl Frontend- als auch Backend-Entwicklung und implementiert <strong>maßgeschneiderte Lösungen</strong> mit modernen Frameworks und SQL/NoSQL-Datenbanken, die auf die spezifischen Anforderungen jedes Unternehmens zugeschnitten sind."
     },
     "tesicnor_backend": {
       "date": "August 2024 - Oktober 2024",
-      "title": "Backend -Entwickler | Tesicnor SL, Noain, Navarra",
-      "description": "Als <strong>Backend-Entwickler</strong> arbeite ich in der Gestaltung und Entwicklung von <strong>Webanwendungen</strong> mit <strong>Spring Boot</strong> für das Backend und verwende unter anderem Technologien wie <strong>JSF, Git, Maven, MySQL</strong>. Darüber hinaus habe ich Erfahrungen in der vollständigen Stapelentwicklung gesammelt, wobei ich mich auf das Backend und relationale Datenbanken konzentriert habe."
+      "title": "Backend-Entwickler | Tesicnor SL, Noáin, Navarra",
+      "description": "Als <strong>Backend-Entwickler</strong> arbeitete ich an der Gestaltung und Entwicklung von <strong>Webanwendungen</strong> mit <strong>Spring Boot</strong> im Backend sowie Technologien wie <strong>JSF, Git, Maven und MySQL</strong>. Außerdem sammelte ich Erfahrung in der Full-Stack-Entwicklung mit Schwerpunkt auf Backend und relationalen Datenbanken."
     },
     "camp": {
       "date": "Sommer 2024",
-      "title": "Camp Counselor | Camp Lonhororn Inks Lake, Texas",
-      "description": "Ich hatte die Möglichkeit, mein <strong>Englisch-Niveau erheblich zu verbessern</strong> durch totales Eintauchen in eine englischsprachige Umgebung. Ich leitete und beaufsichtigte Gruppen von Kindern in verschiedenen Aktivitäten und förderte eine sichere und positive Atmosphäre. Darüber hinaus erhielt ich den Abschluss als <strong>Rettungsschwimmer</strong>, der es mir ermöglichte, die Sicherheit bei aquatischen Aktivitäten zu gewährleisten."
+      "title": "Camp Counselor | Camp Longhorn Inks Lake, Texas",
+      "description": "Ich hatte die Gelegenheit, mein <strong>Englisch deutlich zu verbessern</strong>, indem ich vollständig in ein englischsprachiges Umfeld eingetaucht war. Ich leitete und betreute Gruppen von Kindern bei verschiedenen Aktivitäten und förderte eine sichere und positive Atmosphäre. Zusätzlich erwarb ich die <strong>Rettungsschwimmer</strong>-Zertifizierung, wodurch ich die Sicherheit bei Wasseraktivitäten gewährleisten konnte."
     },
     "tesicnor_intern": {
       "date": "Januar 2024 - Mai 2024",
-      "title": "Praktiziert Backend Developer | Tesicnor SL, Noain, Navarra",
-      "description": "Als <strong>Backend-Entwickler</strong> habe ich an der Gestaltung und Entwicklung von <strong>Webanwendungen</strong> gearbeitet, indem ich <strong>Spring Boot</strong> für das Backend und <strong>Angular</strong> für das Frontend eingesetzt habe. Darüber hinaus habe ich praktische Erfahrungen in der vollständigen Stapelentwicklung gesammelt, wobei der Schwerpunkt auf dem Backend und relationalen Datenbanken wie <strong>MySQL</strong> lag."
+      "title": "Backend-Entwickler Praktikant | Tesicnor SL, Noáin, Navarra",
+      "description": "Als <strong>Backend-Entwickler</strong> war ich an der Gestaltung und Entwicklung von <strong>Webanwendungen</strong> beteiligt, wobei ich <strong>Spring Boot</strong> für das Backend und <strong>Angular</strong> für das Frontend verwendete. Ich sammelte praktische Erfahrung in der Full-Stack-Entwicklung mit Schwerpunkt auf Backend und relationalen Datenbanken wie <strong>MySQL</strong>."
     },
     "burlada": {
       "date": "März 2022 - Juni 2022",
-      "title": "Praktikum in Praktiken | Stadtrat von Burlada",
-      "description": "Während meiner Praxis im <strong>Stadtrat von Burlada</strong> als Informatiker sammelte ich Erfahrung in der <strong>Problemlösung</strong> und <strong>Teamarbeit</strong>. Ich trug zur Entwicklung von kommunalen Computersystemen bei, arbeitete mit Fachleuten zusammen und stärkte meine Leidenschaft für Informatik und das technologische Bereich."
+      "title": "IT-Praktikant | Rathaus von Burlada",
+      "description": "Während meines Praktikums im <strong>Rathaus von Burlada</strong> sammelte ich Erfahrung in <strong>Problemlösung</strong> und <strong>Teamarbeit</strong>. Ich trug zur Entwicklung kommunaler IT-Systeme bei, arbeitete mit Fachleuten zusammen und vertiefte meine Leidenschaft für Informatik und Technologie."
     }
   },
   "projectsSection": {
     "demo": "Demo",
-    "viewDemo": "Siehe Demo",
-    "viewOnGitHub": "Siehe in Github",
-    "moreProjects": "Weitere Projekte sehen",
-    "githubDescription": "Ein Github -Repository namens {{repo}}"
+    "viewDemo": "Demo ansehen",
+    "viewOnGitHub": "Auf GitHub ansehen",
+    "moreProjects": "Weitere Projekte anzeigen",
+    "githubDescription": "Ein GitHub-Repository namens {{repo}}"
   },
   "footer": {
     "rights": "Alle Rechte vorbehalten",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -6,11 +6,11 @@
     "contact": "Contact"
   },
   "badge": {
-    "available": "Available to work"
+    "available": "Available for work"
   },
   "hero": {
     "hello": "Hi! I'm",
-    "description": "Backend and Full Stack developer in Pamplona, Spain 🇪🇸. Passionate about technology, innovation and design. Committed to creating exceptional experiences and creative solutions."
+    "description": "Backend and full-stack developer based in Pamplona, Spain 🇪🇸. Passionate about technology, innovation and design, committed to creating outstanding experiences and creative solutions."
   },
   "section": {
     "experience": "Work experience",
@@ -18,46 +18,46 @@
     "about": "About me"
   },
   "about": {
-    "content": "I am <strong> Mikel Echeverria </strong>, a <strong> Full Stack developer </strong> and <strong> backend </strong> with prominent skills in <strong> problem solving, teamwork and effective communication </strong>. I have a deep passion for the <strong> artificial intelligence </strong> and the <strong> generative models </strong>, areas in which I have extensive knowledge and for which I have developed personal projects. My experience in these technologies allows me to provide innovative solutions that optimize processes and improve efficiency. In addition, I remain in constant learning to be up to date with the latest technological trends and thus contribute positively to challenging projects such as <strong> developer Frontend </strong> and <strong> backend </strong>."
+    "content": "I’m <strong>Mikel Echeverria</strong>, a <strong>Full-Stack</strong> and <strong>Backend developer</strong> with strong skills in <strong>problem solving, teamwork and effective communication</strong>. I have a deep passion for <strong>artificial intelligence</strong> and <strong>generative models</strong>, areas where I have extensive knowledge and have developed personal projects. My experience with these technologies allows me to deliver innovative solutions that optimize processes and improve efficiency. I constantly seek to stay up to date with the latest technological trends so I can contribute positively to demanding projects as a <strong>Frontend</strong> and <strong>Backend developer</strong>."
   },
   "experience": {
     "moreInfo": "More information",
     "codetec": {
-      "date": "January 2025 - News",
-      "title": "Full Stack developer | CODETEC SERVICIOS INFORMICOS SL",
-      "description": "As a <strong>Full Stack developer</strong> in Codetec, I work in the development and maintenance of <strong>business solutions</strong>, specializing in <strong>management, accounting, billing and logistics systems</strong>. I use modern technologies such as <strong>Vue.js, Ionic, Angular and Node.js</strong> to create efficient web and mobile applications that improve our customers' business processes. My work covers both the frontend and backend development, implementing <strong>personalized solutions</strong> with modern frameworks and SQL/NOSQL databases that adapt to the specific needs of each company."
+      "date": "January 2025 - Present",
+      "title": "Full-Stack Developer | CODETEC Servicios Informáticos SL",
+      "description": "As a <strong>Full-Stack Developer</strong> at Codetec I develop and maintain <strong>business solutions</strong>, specialising in <strong>management, accounting, invoicing and logistics systems</strong>. I use modern technologies such as <strong>Vue.js, Ionic, Angular and Node.js</strong> to build efficient web and mobile applications that improve our clients’ business processes. My work covers both the frontend and the backend, implementing <strong>custom solutions</strong> with modern frameworks and SQL/NoSQL databases tailored to each company’s needs."
     },
     "tesicnor_backend": {
       "date": "August 2024 - October 2024",
-      "title": "Backend developer | Tesicnor SL, Noain, Navarra",
-      "description": "As a <strong>Backend developer</strong>, I work in the design and development of <strong>web applications</strong> using <strong>Spring Boot</strong> for the backend as well as technologies such as <strong>JSF, Git, Maven, MySQL</strong>, among others. In addition, I have acquired experience in Full Stack development, with emphasis on the backend and relational databases."
+      "title": "Backend Developer | Tesicnor SL, Noáin, Navarra",
+      "description": "As a <strong>Backend Developer</strong> I worked on the design and development of <strong>web applications</strong> using <strong>Spring Boot</strong> for the backend along with technologies such as <strong>JSF, Git, Maven and MySQL</strong>, among others. I also gained experience in full-stack development, with emphasis on the backend and relational databases."
     },
     "camp": {
       "date": "Summer 2024",
-      "title": "Camp Counselor | Camp Lonhororn Inks Lake, Texas",
-      "description": "I had the opportunity to <strong>significantly improve my English level</strong> through total immersion in an English-speaking environment. I guided and supervised groups of children in various activities, promoting a safe and positive atmosphere. In addition, I obtained the <strong>Lifeguard</strong> degree, which allowed me to guarantee security in aquatic activities."
+      "title": "Camp Counselor | Camp Longhorn Inks Lake, Texas",
+      "description": "I had the opportunity to <strong>significantly improve my English</strong> through total immersion in an English-speaking environment. I led and supervised groups of children in various activities, fostering a safe and positive atmosphere. I also earned a <strong>Lifeguard</strong> certification, which enabled me to ensure safety in aquatic activities."
     },
     "tesicnor_intern": {
       "date": "January 2024 - May 2024",
-      "title": "Practices Backend developer | Tesicnor SL, Noain, Navarra",
-      "description": "As a <strong>Backend developer</strong>, I worked on the design and development of <strong>web applications</strong> using <strong>Spring Boot</strong> for the backend and <strong>Angular</strong> for the frontend. In addition, I acquired practical experience in Full Stack development, with emphasis on the backend and relational databases such as <strong>MySQL</strong>."
+      "title": "Backend Developer Intern | Tesicnor SL, Noáin, Navarra",
+      "description": "As a <strong>Backend Developer</strong> I worked on the design and development of <strong>web applications</strong> using <strong>Spring Boot</strong> for the backend and <strong>Angular</strong> for the frontend. I gained hands-on experience in full-stack development, focusing on the backend and relational databases such as <strong>MySQL</strong>."
     },
     "burlada": {
       "date": "March 2022 - June 2022",
-      "title": "Internship in practices | Burlada City Council",
-      "description": "During my internship at the <strong>City of Burlada</strong> as a computer scientist, I acquired experience in <strong>problem solving</strong> and <strong>teamwork</strong>. I contributed to the development of municipal computer systems, collaborating with professionals and strengthening my passion for computer science and the technological field."
+      "title": "IT Intern | Burlada City Council",
+      "description": "During my internship at the <strong>Burlada City Council</strong> as an IT specialist, I gained experience in <strong>problem solving</strong> and <strong>teamwork</strong>. I contributed to the development of municipal computer systems, working alongside professionals and strengthening my passion for computing and technology."
     }
   },
   "projectsSection": {
     "demo": "Demo",
-    "viewDemo": "See demo",
-    "viewOnGitHub": "See in Github",
+    "viewDemo": "View demo",
+    "viewOnGitHub": "View on GitHub",
     "moreProjects": "See more projects",
-    "githubDescription": "A github repository called {{repo}}"
+    "githubDescription": "A GitHub repository named {{repo}}"
   },
   "footer": {
     "rights": "All rights reserved",
-    "source": "Source Code",
+    "source": "Source code",
     "about": "About me",
     "contact": "Contact"
   },

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -9,8 +9,8 @@
     "available": "Disponible para trabajar"
   },
   "hero": {
-    "hello": "Hola! soy",
-    "description": "Desarrollador Backend y Full Stack en Pamplona, España 🇪🇸. Apasionado por la tecnología, innovación y el diseño. Comprometido en crear experiencias excepcionales y soluciones creativas."
+    "hello": "¡Hola! Soy",
+    "description": "Desarrollador Backend y Full Stack en Pamplona, España 🇪🇸. Apasionado por la tecnología, la innovación y el diseño. Comprometido con la creación de experiencias excepcionales y soluciones creativas."
   },
   "section": {
     "experience": "Experiencia laboral",
@@ -24,7 +24,7 @@
     "moreInfo": "Más información",
     "codetec": {
       "date": "Enero 2025 - Actualidad",
-      "title": "Desarrollador Full Stack | Codetec Servicios Informaticos SL",
+      "title": "Desarrollador Full Stack | CODETEC Servicios Informáticos SL",
       "description": "Como <strong>Desarrollador Full Stack</strong> en Codetec, trabajo en el desarrollo y mantenimiento de <strong>soluciones empresariales</strong>, especializándome en <strong>gestión, contabilidad, facturación y logística</strong>. Utilizo tecnologías modernas como <strong>Vue.js, Ionic, Angular y Node.js</strong> para crear aplicaciones web y móviles eficientes que mejoran los procesos de negocio de nuestros clientes. Mi trabajo abarca tanto el desarrollo frontend como backend, implementando <strong>soluciones personalizadas</strong> con frameworks modernos y bases de datos SQL/NoSQL que se adaptan a las necesidades específicas de cada empresa."
     },
     "tesicnor_backend": {
@@ -35,7 +35,7 @@
     "camp": {
       "date": "Verano 2024",
       "title": "Camp Counselor | Camp Longhorn Inks Lake, Texas",
-      "description": "Tuve la oportunidad de <strong>mejorar significativamente mi nivel de inglés</strong> a través de la inmersión total en un entorno de habla inglesa. Guié y supervisé a grupos de niños en diversas actividades, fomentando un ambiente seguro y positivo. Además, obtuve la titulación de <strong>socorrista (lifeguard)</strong>, lo que me permitió garantizar la seguridad en actividades acuáticas."
+      "description": "Tuve la oportunidad de <strong>mejorar significativamente mi nivel de inglés</strong> a través de la inmersión total en un entorno de habla inglesa. Guié y supervisé a grupos de niños en diversas actividades, fomentando un ambiente seguro y positivo. Además, obtuve la titulación de <strong>socorrista</strong>, lo que me permitió garantizar la seguridad en actividades acuáticas."
     },
     "tesicnor_intern": {
       "date": "Enero 2024 - Mayo 2024",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -2,7 +2,7 @@
   "nav": {
     "experience": "Expérience",
     "projects": "Projets",
-    "about": "Sur moi",
+    "about": "À propos de moi",
     "contact": "Contact"
   },
   "badge": {
@@ -10,55 +10,55 @@
   },
   "hero": {
     "hello": "Bonjour ! Je suis",
-    "description": "Backend et développeur complet à Pampelune, Espagne 🇪🇸. Passionné par la technologie, l'innovation et le design. Engagé à créer des expériences exceptionnelles et des solutions créatives."
+    "description": "Développeur backend et full-stack basé à Pampelune, Espagne 🇪🇸. Passionné de technologie, d'innovation et de design, engagé à créer des expériences exceptionnelles et des solutions créatives."
   },
   "section": {
-    "experience": "Expérience de travail",
+    "experience": "Expérience professionnelle",
     "projects": "Projets",
-    "about": "Sur moi"
+    "about": "À propos de moi"
   },
   "about": {
-    "content": "Je suis <strong> Mikel Echeverria </strong>, un <strong> développeur de pile complet </strong> et <strong> backend </strong> avec des compétences éminentes dans la résolution de problèmes <strong>, le travail d'équipe et la communication efficace </strong>. J'ai une profonde passion pour l'intelligence artificielle <strong> </strong> et les modèles génératifs <strong> </strong>, les domaines dans lesquels j'ai des connaissances approfondies et pour lesquelles j'ai développé des projets personnels. Mon expérience dans ces technologies me permet de fournir des solutions innovantes qui optimisent les processus et améliorent l'efficacité. De plus, je reste constamment en apprenant à être à jour avec les dernières tendances technologiques et contribue donc positivement à des projets difficiles tels que <strong> développeur frontend </strong> et <strong> backend </strong>."
+    "content": "Je suis <strong>Mikel Echeverria</strong>, <strong>développeur full-stack</strong> et <strong>backend</strong> doté de solides compétences en <strong>résolution de problèmes, travail d'équipe et communication efficace</strong>. Je suis passionné par l'<strong>intelligence artificielle</strong> et les <strong>modèles génératifs</strong>, domaines dans lesquels je possède de vastes connaissances et pour lesquels j'ai réalisé des projets personnels. Mon expérience dans ces technologies me permet de proposer des solutions innovantes qui optimisent les processus et améliorent l'efficacité. Je reste en apprentissage continu pour me tenir informé des dernières tendances technologiques et ainsi contribuer positivement à des projets exigeants en tant que <strong>développeur frontend</strong> et <strong>backend</strong>."
   },
   "experience": {
     "moreInfo": "Plus d'informations",
     "codetec": {
-      "date": "Janvier 2025 - News",
-      "title": "Développeur de pile complet | Codetec Servicios Informecos sl",
-      "description": "En tant que <strong>développeur Full Stack</strong> chez Codetec, je travaille au développement et à la maintenance de <strong>solutions d'entreprise</strong>, en me spécialisant dans <strong>la gestion, la comptabilité, la facturation et la logistique</strong>. J'utilise des technologies modernes telles que <strong>Vue.js, Ionic, Angular et Node.js</strong> pour créer des applications web et mobiles efficaces qui améliorent les processus métier de nos clients. Mon travail couvre à la fois le développement frontend et backend, en mettant en œuvre des <strong>solutions personnalisées</strong> avec des frameworks modernes et des bases de données SQL/NoSQL qui s'adaptent aux besoins spécifiques de chaque entreprise."
+      "date": "Janvier 2025 - Présent",
+      "title": "Développeur Full-Stack | CODETEC Servicios Informáticos SL",
+      "description": "En tant que <strong>développeur full-stack</strong> chez Codetec, je participe au développement et à la maintenance de <strong>solutions d'entreprise</strong>, en me spécialisant dans les <strong>systèmes de gestion, de comptabilité, de facturation et de logistique</strong>. J'utilise des technologies modernes telles que <strong>Vue.js, Ionic, Angular et Node.js</strong> pour créer des applications web et mobiles efficaces qui améliorent les processus de nos clients. Mon travail couvre à la fois le frontend et le backend, en mettant en œuvre des <strong>solutions personnalisées</strong> avec des frameworks modernes et des bases de données SQL/NoSQL adaptées aux besoins de chaque entreprise."
     },
     "tesicnor_backend": {
-      "date": "Août 2024 - octobre 2024",
-      "title": "Développeur backend | Tesicnor Sl, Noain, Navarra",
-      "description": "En tant que <strong>développeur Backend</strong>, je travaille à la conception et au développement d'<strong>applications web</strong> utilisant <strong>Spring Boot</strong> pour le backend ainsi que des technologies telles que <strong>JSF, Git, Maven, MySQL</strong>, entre autres. De plus, j'ai acquis de l'expérience dans le développement Full Stack, avec un accent sur le backend et les bases de données relationnelles."
+      "date": "Août 2024 - Octobre 2024",
+      "title": "Développeur Backend | Tesicnor SL, Noáin, Navarre",
+      "description": "En tant que <strong>développeur backend</strong>, j'ai travaillé sur la conception et le développement d'<strong>applications web</strong> en utilisant <strong>Spring Boot</strong> pour le backend ainsi que des technologies telles que <strong>JSF, Git, Maven et MySQL</strong>. J'ai également acquis de l'expérience en développement full-stack, avec un accent sur le backend et les bases de données relationnelles."
     },
     "camp": {
       "date": "Été 2024",
-      "title": "Conseiller du camp | Camp Lonhororn Inks Lake, Texas",
-      "description": "J'ai eu l'opportunité d'<strong>améliorer considérablement mon niveau d'anglais</strong> grâce à une immersion totale dans un environnement anglophone. J'ai guidé et supervisé des groupes d'enfants dans diverses activités, favorisant une atmosphère sûre et positive. De plus, j'ai obtenu le diplôme de <strong>sauveteur</strong>, ce qui m'a permis de garantir la sécurité lors des activités aquatiques."
+      "title": "Moniteur de camp | Camp Longhorn Inks Lake, Texas",
+      "description": "J'ai eu l'opportunité d'<strong>améliorer considérablement mon anglais</strong> grâce à une immersion totale dans un environnement anglophone. J'ai encadré et supervisé des groupes d'enfants lors de diverses activités, favorisant une atmosphère sûre et positive. J'ai également obtenu la certification de <strong>maître-nageur sauveteur</strong>, ce qui m'a permis de garantir la sécurité lors des activités aquatiques."
     },
     "tesicnor_intern": {
-      "date": "Janvier 2024 - mai 2024",
-      "title": "Pratiques Développeur backend | Tesicnor Sl, Noain, Navarra",
-      "description": "En tant que <strong>développeur Backend</strong>, j'ai travaillé sur la conception et le développement d'<strong>applications web</strong> utilisant <strong>Spring Boot</strong> pour le backend et <strong>Angular</strong> pour le frontend. De plus, j'ai acquis une expérience pratique dans le développement Full Stack, avec un accent sur le backend et les bases de données relationnelles telles que <strong>MySQL</strong>."
+      "date": "Janvier 2024 - Mai 2024",
+      "title": "Stagiaire Développeur Backend | Tesicnor SL, Noáin, Navarre",
+      "description": "En tant que <strong>développeur backend</strong>, j'ai participé à la conception et au développement d'<strong>applications web</strong> en utilisant <strong>Spring Boot</strong> pour le backend et <strong>Angular</strong> pour le frontend. J'ai acquis une expérience pratique en développement full-stack, avec un accent sur le backend et les bases de données relationnelles telles que <strong>MySQL</strong>."
     },
     "burlada": {
-      "date": "Mars 2022 - juin 2022",
-      "title": "Stage dans les pratiques | Conseil municipal de Burlada",
-      "description": "Au cours de mon stage à la <strong>mairie de Burlada</strong> en tant qu'informaticien, j'ai acquis de l'expérience en <strong>résolution de problèmes</strong> et en <strong>travail d'équipe</strong>. J'ai contribué au développement de systèmes informatiques municipaux, collaboré avec des professionnels et renforcé ma passion pour l'informatique et le domaine technologique."
+      "date": "Mars 2022 - Juin 2022",
+      "title": "Stagiaire Informatique | Mairie de Burlada",
+      "description": "Lors de mon stage à la <strong>mairie de Burlada</strong> en tant qu'informaticien, j'ai acquis de l'expérience en <strong>résolution de problèmes</strong> et en <strong>travail d'équipe</strong>. J'ai contribué au développement de systèmes informatiques municipaux, en collaboration avec des professionnels et en renforçant ma passion pour l'informatique et la technologie."
     }
   },
   "projectsSection": {
     "demo": "Démo",
     "viewDemo": "Voir la démo",
-    "viewOnGitHub": "Voir dans github",
+    "viewOnGitHub": "Voir sur GitHub",
     "moreProjects": "Voir plus de projets",
-    "githubDescription": "Un référentiel GitHub appelé {{repo}}"
+    "githubDescription": "Un dépôt GitHub nommé {{repo}}"
   },
   "footer": {
     "rights": "Tous droits réservés",
     "source": "Code source",
-    "about": "Sur moi",
+    "about": "À propos de moi",
     "contact": "Contact"
   },
   "languageNames": {

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -2,63 +2,63 @@
   "nav": {
     "experience": "Esperienza",
     "projects": "Progetti",
-    "about": "Su di me",
+    "about": "Chi sono",
     "contact": "Contatto"
   },
   "badge": {
-    "available": "Disponibile per il lavoro"
+    "available": "Disponibile a lavorare"
   },
   "hero": {
     "hello": "Ciao! Sono",
-    "description": "Sviluppatore di back -end e full stack a Pamplona, Spagna 🇪🇸. Appassionato di tecnologia, innovazione e design. Impegnato a creare esperienze eccezionali e soluzioni creative."
+    "description": "Sviluppatore backend e full-stack con sede a Pamplona, Spagna 🇪🇸. Appassionato di tecnologia, innovazione e design, impegnato a creare esperienze eccezionali e soluzioni creative."
   },
   "section": {
-    "experience": "Esperienza di lavoro",
+    "experience": "Esperienza lavorativa",
     "projects": "Progetti",
-    "about": "Su di me"
+    "about": "Chi sono"
   },
   "about": {
-    "content": "Sono <strong> mikel echeverria </strong>, uno sviluppatore di stack completo </strong> e <strong> backend </strong> con abilità importanti in <strong> risoluzione di problemi, lavoro di squadra e comunicazione efficace </strong>. Ho una profonda passione per l'intelligenza artificiale </strong> e i modelli generativi <strong> </strong>, aree in cui ho ampie conoscenze e per le quali ho sviluppato progetti personali. La mia esperienza in queste tecnologie mi consente di fornire soluzioni innovative che ottimizzano i processi e migliorano l'efficienza. Inoltre, rimango in costante apprendimento per essere aggiornato con le ultime tendenze tecnologiche e quindi contribuisco positivamente a progetti impegnativi come <strong> sviluppatore frontend </strong> e <strong> backend </strong>."
+    "content": "Sono <strong>Mikel Echeverria</strong>, <strong>sviluppatore full-stack</strong> e <strong>backend</strong> con spiccate capacità di <strong>problem solving, lavoro di squadra e comunicazione efficace</strong>. Ho una profonda passione per l'<strong>intelligenza artificiale</strong> e i <strong>modelli generativi</strong>, ambiti in cui possiedo vaste conoscenze e per i quali ho realizzato progetti personali. L'esperienza in queste tecnologie mi consente di fornire soluzioni innovative che ottimizzano i processi e migliorano l'efficienza. Inoltre, sono costantemente aggiornato sulle ultime tendenze tecnologiche per contribuire in modo positivo a progetti impegnativi come <strong>sviluppatore frontend</strong> e <strong>backend</strong>."
   },
   "experience": {
-    "moreInfo": "Maggiori informazioni",
+    "moreInfo": "Ulteriori informazioni",
     "codetec": {
-      "date": "Gennaio 2025 - Notizie",
-      "title": "Sviluppatore di stack completo | COdetec Servicios Informicos SL",
-      "description": "Come <strong>Sviluppatore Full Stack</strong> in Codetec, lavoro nello sviluppo e nella manutenzione di <strong>soluzioni aziendali</strong>, specializzandomi in <strong>gestione, contabilità, fatturazione e logistica</strong>. Utilizzo tecnologie moderne come <strong>Vue.js, Ionic, Angular e Node.js</strong> per creare applicazioni web e mobili efficienti che migliorano i processi aziendali dei nostri clienti. Il mio lavoro copre sia lo sviluppo frontend che backend, implementando <strong>soluzioni personalizzate</strong> con framework moderni e database SQL/NoSQL che si adattano alle esigenze specifiche di ogni azienda."
+      "date": "Gennaio 2025 - Presente",
+      "title": "Sviluppatore Full-Stack | CODETEC Servicios Informáticos SL",
+      "description": "Come <strong>sviluppatore full-stack</strong> in Codetec mi occupo dello sviluppo e della manutenzione di <strong>soluzioni aziendali</strong>, specializzandomi in <strong>sistemi di gestione, contabilità, fatturazione e logistica</strong>. Utilizzo tecnologie moderne come <strong>Vue.js, Ionic, Angular e Node.js</strong> per creare applicazioni web e mobile efficienti che migliorano i processi aziendali dei nostri clienti. Il mio lavoro comprende sia il frontend sia il backend, implementando <strong>soluzioni personalizzate</strong> con framework moderni e database SQL/NoSQL adattati alle esigenze di ogni azienda."
     },
     "tesicnor_backend": {
-      "date": "Agosto 2024 - ottobre 2024",
-      "title": "Sviluppatore di backend | Tesicnor SL, Noain, Navarra",
-      "description": "Come <strong>Sviluppatore Backend</strong>, lavoro nella progettazione e nello sviluppo di <strong>applicazioni web</strong> utilizzando <strong>Spring Boot</strong> per il backend oltre a tecnologie come <strong>JSF, Git, Maven, MySQL</strong>, tra le altre. Inoltre, ho acquisito esperienza nello sviluppo full stack, con enfasi sul backend e sui database relazionali."
+      "date": "Agosto 2024 - Ottobre 2024",
+      "title": "Sviluppatore Backend | Tesicnor SL, Noáin, Navarra",
+      "description": "Come <strong>sviluppatore backend</strong> ho lavorato alla progettazione e allo sviluppo di <strong>applicazioni web</strong> utilizzando <strong>Spring Boot</strong> per il backend insieme a tecnologie come <strong>JSF, Git, Maven e MySQL</strong>. Ho inoltre acquisito esperienza nello sviluppo full-stack, con enfasi sul backend e sui database relazionali."
     },
     "camp": {
       "date": "Estate 2024",
-      "title": "Consigliere del campo | Camp Lonhororn Inks Lake, Texas",
-      "description": "Ho avuto l'opportunità di <strong>migliorare significativamente il mio livello di inglese</strong> attraverso l'immersione totale in un ambiente di lingua inglese. Ho guidato e supervisionato gruppi di bambini in varie attività, promuovendo un ambiente sicuro e positivo. Inoltre, ho ottenuto la qualifica di <strong>bagnino</strong>, che mi ha permesso di garantire la sicurezza nelle attività acquatiche."
+      "title": "Camp Counselor | Camp Longhorn Inks Lake, Texas",
+      "description": "Ho avuto l'opportunità di <strong>migliorare notevolmente il mio inglese</strong> grazie a un'immersione totale in un ambiente anglofono. Ho guidato e supervisionato gruppi di bambini in diverse attività, promuovendo un ambiente sicuro e positivo. Ho inoltre conseguito la certificazione di <strong>bagnino</strong>, che mi ha permesso di garantire la sicurezza nelle attività acquatiche."
     },
     "tesicnor_intern": {
-      "date": "Gennaio 2024 - maggio 2024",
-      "title": "Pratiche Sviluppatore di backend | Tesicnor SL, Noain, Navarra",
-      "description": "Come <strong>Sviluppatore Backend</strong>, ho lavorato alla progettazione e allo sviluppo di <strong>applicazioni web</strong> utilizzando <strong>Spring Boot</strong> per il backend e <strong>Angular</strong> per il frontend. Inoltre, ho acquisito esperienza pratica nello sviluppo full stack, con enfasi sul backend e sui database relazionali come <strong>MySQL</strong>."
+      "date": "Gennaio 2024 - Maggio 2024",
+      "title": "Tirocinante Sviluppatore Backend | Tesicnor SL, Noáin, Navarra",
+      "description": "Come <strong>sviluppatore backend</strong> ho partecipato alla progettazione e allo sviluppo di <strong>applicazioni web</strong> utilizzando <strong>Spring Boot</strong> per il backend e <strong>Angular</strong> per il frontend. Ho acquisito esperienza pratica nello sviluppo full-stack, con particolare attenzione al backend e ai database relazionali come <strong>MySQL</strong>."
     },
     "burlada": {
-      "date": "Marzo 2022 - giugno 2022",
-      "title": "Stage in pratiche | Consiglio comunale di Burlada",
-      "description": "Durante il mio tirocinio presso il <strong>Comune di Burlada</strong> come informatico, ho acquisito esperienza nella <strong>risoluzione dei problemi</strong> e nel <strong>lavoro di squadra</strong>. Ho contribuito allo sviluppo di sistemi informatici comunali, collaborando con professionisti e rafforzando la mia passione per l'informatica e il campo tecnologico."
+      "date": "Marzo 2022 - Giugno 2022",
+      "title": "Tirocinio informatico | Comune di Burlada",
+      "description": "Durante il mio tirocinio presso il <strong>Comune di Burlada</strong> come informatico ho maturato esperienza nella <strong>risoluzione dei problemi</strong> e nel <strong>lavoro di squadra</strong>. Ho contribuito allo sviluppo dei sistemi informatici comunali, collaborando con professionisti e rafforzando la mia passione per l'informatica e la tecnologia."
     }
   },
   "projectsSection": {
     "demo": "Demo",
     "viewDemo": "Vedi demo",
-    "viewOnGitHub": "Vedi in GitHub",
+    "viewOnGitHub": "Vedi su GitHub",
     "moreProjects": "Vedi altri progetti",
-    "githubDescription": "Un repository GitHub chiamato {{Repo}}"
+    "githubDescription": "Un repository GitHub chiamato {{repo}}"
   },
   "footer": {
     "rights": "Tutti i diritti riservati",
     "source": "Codice sorgente",
-    "about": "Su di me",
+    "about": "Chi sono",
     "contact": "Contatto"
   },
   "languageNames": {


### PR DESCRIPTION
## Summary
- refine translations across English, Spanish, French, German and Italian locale files
- correct phrasing, punctuation and company names for consistency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68965ee571d4832ca1a778667d14cac1