### PR TITLE
Use past tense for Codetec experience description

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -25,7 +25,7 @@
     "codetec": {
       "date": "Januar 2025 - September",
       "title": "Full-Stack-Entwickler | CODETEC Servicios Informáticos SL",
-      "description": "Als <strong>Full-Stack-Entwickler</strong> bei Codetec entwickle und pflege ich <strong>Geschäftslösungen</strong> und spezialisiere mich auf <strong>Management-, Buchhaltungs-, Abrechnungs- und Logistiksysteme</strong>. Mit modernen Technologien wie <strong>Vue.js, Ionic, Angular und Node.js</strong> erstelle ich effiziente Web- und Mobilanwendungen, die die Geschäftsprozesse unserer Kunden verbessern. Meine Arbeit umfasst sowohl Frontend- als auch Backend-Entwicklung und implementiert <strong>maßgeschneiderte Lösungen</strong> mit modernen Frameworks und SQL/NoSQL-Datenbanken, die auf die spezifischen Anforderungen jedes Unternehmens zugeschnitten sind."
+      "description": "Als <strong>Full-Stack-Entwickler</strong> bei Codetec entwickelte und pflegte ich <strong>Geschäftslösungen</strong> und spezialisierte mich auf <strong>Management-, Buchhaltungs-, Abrechnungs- und Logistiksysteme</strong>. Mit modernen Technologien wie <strong>Vue.js, Ionic, Angular und Node.js</strong> erstellte ich effiziente Web- und Mobilanwendungen, die die Geschäftsprozesse unserer Kunden verbesserten. Meine Arbeit umfasste sowohl die Frontend- als auch die Backend-Entwicklung und die Implementierung <strong>maßgeschneiderter Lösungen</strong> mit modernen Frameworks und SQL/NoSQL-Datenbanken, die auf die spezifischen Anforderungen jedes Unternehmens zugeschnitten waren."
     },
     "tesicnor_backend": {
       "date": "August 2024 - Oktober 2024",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -25,7 +25,7 @@
     "codetec": {
       "date": "January 2025 - September",
       "title": "Full-Stack Developer | CODETEC Servicios Informáticos SL",
-      "description": "As a <strong>Full-Stack Developer</strong> at Codetec I develop and maintain <strong>business solutions</strong>, specialising in <strong>management, accounting, invoicing and logistics systems</strong>. I use modern technologies such as <strong>Vue.js, Ionic, Angular and Node.js</strong> to build efficient web and mobile applications that improve our clients’ business processes. My work covers both the frontend and the backend, implementing <strong>custom solutions</strong> with modern frameworks and SQL/NoSQL databases tailored to each company’s needs."
+      "description": "As a <strong>Full-Stack Developer</strong> at Codetec, I developed and maintained <strong>business solutions</strong>, specialising in <strong>management, accounting, invoicing and logistics systems</strong>. I used modern technologies such as <strong>Vue.js, Ionic, Angular and Node.js</strong> to build efficient web and mobile applications that improved our clients’ business processes. My work covered both the frontend and the backend, implementing <strong>custom solutions</strong> with modern frameworks and SQL/NoSQL databases tailored to each company’s needs."
     },
     "tesicnor_backend": {
       "date": "August 2024 - October 2024",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -25,7 +25,7 @@
     "codetec": {
       "date": "Enero 2025 - Septiembre",
       "title": "Desarrollador Full Stack | CODETEC Servicios Informáticos SL",
-      "description": "Como <strong>Desarrollador Full Stack</strong> en Codetec, trabajo en el desarrollo y mantenimiento de <strong>soluciones empresariales</strong>, especializándome en <strong>gestión, contabilidad, facturación y logística</strong>. Utilizo tecnologías modernas como <strong>Vue.js, Ionic, Angular y Node.js</strong> para crear aplicaciones web y móviles eficientes que mejoran los procesos de negocio de nuestros clientes. Mi trabajo abarca tanto el desarrollo frontend como backend, implementando <strong>soluciones personalizadas</strong> con frameworks modernos y bases de datos SQL/NoSQL que se adaptan a las necesidades específicas de cada empresa."
+      "description": "Como <strong>Desarrollador Full Stack</strong> en Codetec, trabajé en el desarrollo y mantenimiento de <strong>soluciones empresariales</strong>, especializándome en <strong>gestión, contabilidad, facturación y logística</strong>. Utilicé tecnologías modernas como <strong>Vue.js, Ionic, Angular y Node.js</strong> para crear aplicaciones web y móviles eficientes que mejoraron los procesos de negocio de nuestros clientes. Mi trabajo abarcó tanto el desarrollo frontend como backend, implementando <strong>soluciones personalizadas</strong> con frameworks modernos y bases de datos SQL/NoSQL que se adaptaron a las necesidades específicas de cada empresa."
     },
     "tesicnor_backend": {
       "date": "Agosto 2024 - Octubre 2024",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -25,7 +25,7 @@
     "codetec": {
       "date": "Janvier 2025 - Septembre",
       "title": "Développeur Full-Stack | CODETEC Servicios Informáticos SL",
-      "description": "En tant que <strong>développeur full-stack</strong> chez Codetec, je participe au développement et à la maintenance de <strong>solutions d'entreprise</strong>, en me spécialisant dans les <strong>systèmes de gestion, de comptabilité, de facturation et de logistique</strong>. J'utilise des technologies modernes telles que <strong>Vue.js, Ionic, Angular et Node.js</strong> pour créer des applications web et mobiles efficaces qui améliorent les processus de nos clients. Mon travail couvre à la fois le frontend et le backend, en mettant en œuvre des <strong>solutions personnalisées</strong> avec des frameworks modernes et des bases de données SQL/NoSQL adaptées aux besoins de chaque entreprise."
+      "description": "En tant que <strong>développeur full-stack</strong> chez Codetec, j'ai participé au développement et à la maintenance de <strong>solutions d'entreprise</strong>, en me spécialisant dans les <strong>systèmes de gestion, de comptabilité, de facturation et de logistique</strong>. J'ai utilisé des technologies modernes telles que <strong>Vue.js, Ionic, Angular et Node.js</strong> pour créer des applications web et mobiles efficaces qui amélioraient les processus de nos clients. Mon travail couvrait à la fois le frontend et le backend, en mettant en œuvre des <strong>solutions personnalisées</strong> avec des frameworks modernes et des bases de données SQL/NoSQL adaptées aux besoins de chaque entreprise."
     },
     "tesicnor_backend": {
       "date": "Août 2024 - Octobre 2024",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -25,7 +25,7 @@
     "codetec": {
       "date": "Gennaio 2025 - Settembre",
       "title": "Sviluppatore Full-Stack | CODETEC Servicios Informáticos SL",
-      "description": "Come <strong>sviluppatore full-stack</strong> in Codetec mi occupo dello sviluppo e della manutenzione di <strong>soluzioni aziendali</strong>, specializzandomi in <strong>sistemi di gestione, contabilità, fatturazione e logistica</strong>. Utilizzo tecnologie moderne come <strong>Vue.js, Ionic, Angular e Node.js</strong> per creare applicazioni web e mobile efficienti che migliorano i processi aziendali dei nostri clienti. Il mio lavoro comprende sia il frontend sia il backend, implementando <strong>soluzioni personalizzate</strong> con framework moderni e database SQL/NoSQL adattati alle esigenze di ogni azienda."
+      "description": "Come <strong>sviluppatore full-stack</strong> in Codetec mi sono occupato dello sviluppo e della manutenzione di <strong>soluzioni aziendali</strong>, specializzandomi in <strong>sistemi di gestione, contabilità, fatturazione e logistica</strong>. Ho utilizzato tecnologie moderne come <strong>Vue.js, Ionic, Angular e Node.js</strong> per creare applicazioni web e mobile efficienti che miglioravano i processi aziendali dei nostri clienti. Il mio lavoro comprendeva sia il frontend sia il backend, implementando <strong>soluzioni personalizzate</strong> con framework moderni e database SQL/NoSQL che si adattavano alle esigenze di ogni azienda."
     },
     "tesicnor_backend": {
       "date": "Agosto 2024 - Ottobre 2024",

--- a/src/components/Experiences.astro
+++ b/src/components/Experiences.astro
@@ -7,7 +7,7 @@ const EXPERIENCES = [
     dateKey: "experience.codetec.date",
     title: "Desarrollador Full Stack | Codetec Servicios Informaticos SL",
     titleKey: "experience.codetec.title",
-    description: `Como Desarrollador Full Stack en Codetec, trabajo en el desarrollo y mantenimiento de soluciones empresariales, especializándome en sistemas de gestión, contabilidad, facturación y logística. Utilizo tecnologías modernas como Vue.js, Ionic, Angular y Node.js para crear aplicaciones web y móviles eficientes que mejoran los procesos de negocio de nuestros clientes. Mi trabajo abarca tanto el desarrollo frontend como backend, implementando soluciones personalizadas con frameworks modernos y bases de datos SQL/NoSQL que se adaptan a las necesidades específicas de cada empresa.`,
+    description: `Como Desarrollador Full Stack en Codetec, trabajé en el desarrollo y mantenimiento de soluciones empresariales, especializándome en sistemas de gestión, contabilidad, facturación y logística. Utilicé tecnologías modernas como Vue.js, Ionic, Angular y Node.js para crear aplicaciones web y móviles eficientes que mejoraron los procesos de negocio de nuestros clientes. Mi trabajo abarcó tanto el desarrollo frontend como backend, implementando soluciones personalizadas con frameworks modernos y bases de datos SQL/NoSQL que se adaptaron a las necesidades específicas de cada empresa.`,
     descriptionKey: "experience.codetec.description",
     link: "https://www.codetec.es/",
     isFirst: true,


### PR DESCRIPTION
## Summary
- rewrite Codetec experience description in past tense
- mirror past-tense wording across Spanish, English, French, German, and Italian translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b56b9cff5c832c848112f0ff5b0e34